### PR TITLE
Zotero extra

### DIFF
--- a/src/sub-commands.ts
+++ b/src/sub-commands.ts
@@ -474,6 +474,10 @@ subParsersMap.set('field', function (subparsers, subCmdName) {
     nargs: 1,
     help: 'You have to supply the version of the item via the --version argument or else the latest version will be used.',
   });
+  argparser.add_argument('--extra', {
+    action: 'store_true',
+    help: 'The field is in the extra field instead of the zotero official fields.',
+  });
 });
 // TODO: Fix help text and text fundtion.
 subParsersMap.set('extra-append', function (subparsers, subCmdName) {

--- a/src/zotero-interface.ts
+++ b/src/zotero-interface.ts
@@ -170,6 +170,7 @@ namespace ZoteroTypes {
   export interface IFieldArgs extends ZoteroTypes.IItemArgs {
     field: string;
     value?: string;
+    extra?: boolean;
   }
 
   export interface IUpdateUrlArgs extends ZoteroTypes.IUpdateItemArgs {

--- a/src/zotero-lib.ts
+++ b/src/zotero-lib.ts
@@ -1686,8 +1686,8 @@ class Zotero {
 
   public get_doi_from_item(item) {
     let doi = '';
-    if ('doi' in item) {
-      doi = item.doi;
+    if ('DOI' in item) {
+      doi = item.DOI;
     } else {
       item.extra.split('\n').forEach((element) => {
         var mymatch = element.match(/^DOI\:\s*(.*?)\s*$/);

--- a/src/zotero-lib.ts
+++ b/src/zotero-lib.ts
@@ -2457,9 +2457,35 @@ class Zotero {
       item = await this.item(args);
       thisversion = item.version;
     }
+    let extra = '';
+    let extraarr = [];
+    if (args.extra) {
+      extra = item.extra;
+      extraarr = extra.split('\n');
+    }
+    const getExtra = (field) => {
+      let i = -1;
+      for (const value of extraarr) {
+        i++;
+        if (value.match(new RegExp('^' + field + '\\:'))) {
+          return i;
+        }
+      }
+      return -1;
+    };
     const myobj = {};
     if (args.value) {
-      myobj[args.field] = as_value(args.value);
+      if (args.extra) {
+        const fieldIndex = getExtra(args.field);
+        if (fieldIndex == -1) {
+          extraarr.push(args.field + ': ' + as_value(args.value));
+        } else {
+          extraarr[fieldIndex] = args.field + ': ' + as_value(args.value);
+        }
+        myobj['extra'] = extraarr.join('\n');
+      } else {
+        myobj[args.field] = as_value(args.value);
+      }
       const updateargs = {
         key: args.key,
         version: thisversion,
@@ -2478,6 +2504,12 @@ class Zotero {
         return this.message(1, 'update failed');
       }
     } else {
+      if (args.extra) {
+        const fieldIndex = getExtra(args.field);
+
+        return extraarr[fieldIndex].split(':').slice(1).join(':').trim();
+      }
+
       return item[args.field];
       //logger.info(item[args.field]);
       //process.exit(1);

--- a/tests/test_get_doi.js
+++ b/tests/test_get_doi.js
@@ -5,13 +5,11 @@ const Zotero = require('../build/zotero-lib');
 const fs = require('fs');
 
 async function main() {
-  var zotero = new Zotero({ verbose: false, 'group-id': 2259720 });
+  const zotero = new Zotero({ verbose: false, 'group-id': 2259720 });
   const key = 'NMF7H2HP';
   console.log('--------------------------------');
   const doi = await zotero.get_doi({ key: key });
   console.log(doi);
-  // console.log('TEMPORARY=' + JSON.stringify(item, null, 2));
-  // const item = await zotero.item({ key: key });
   return 0;
 }
 

--- a/tests/test_get_doi.js
+++ b/tests/test_get_doi.js
@@ -1,0 +1,18 @@
+/*
+Testing record creation.
+*/
+const Zotero = require('../build/zotero-lib');
+const fs = require('fs');
+
+async function main() {
+  var zotero = new Zotero({ verbose: false, 'group-id': 2259720 });
+  const key = 'NMF7H2HP';
+  console.log('--------------------------------');
+  const doi = await zotero.get_doi({ key: key });
+  console.log(doi);
+  // console.log('TEMPORARY=' + JSON.stringify(item, null, 2));
+  // const item = await zotero.item({ key: key });
+  return 0;
+}
+
+main();


### PR DESCRIPTION
## Add extra field manipulation read field and write field

### examples used

-  View current `gsrank` extra field

```bash
npm run dev -- field --extra  --key zotero://select/groups/5478983/items/9DIDHVUE --field gsrank  
```

- Modify `gsrank extra field

```bash
npm run dev -- field --extra  --key zotero://select/groups/5478983/items/9DIDHVUE --field gsrank --value 999 
```

- Add new field to extra field

```bash
npm run dev -- field --extra  --key zotero://select/groups/5478983/items/9DIDHVUE --field test_api --value 'can add'
```

- Test that the code didn't broke for other than extra field

```bash
npm run dev -- field  --key zotero://select/groups/5478983/items/9DIDHVUE --field date --value 9999
```

