### PR TITLE
Implement extra field support for read and modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,31 @@ zotero-lib items --filter '{"limit": 10}'
 
 ### field
 
+This sub-command can be used to fetch field information
+
+```bash
+zoetro-lib field --key key-here --field field-name
+```
+
+Modify field information
+
+```bash
+zoetro-lib field --key key-here --field field-name --value new-value
+```
+
+Or with `--extra` to fetch extra information
+
+```bash
+zoetro-lib field --extra --key key-here --field field-name
+```
+
+And modify extra information
+
+```bash
+zoetro-lib field --extra --key key-here --field field-name --value new-value
+```
+
+
 ### update-url
 
 ### get-doi

--- a/src/sub-commands.ts
+++ b/src/sub-commands.ts
@@ -470,6 +470,10 @@ subParsersMap.set('field', function (subparsers, subCmdName) {
     action: 'store',
     help: 'The value for the update (if not provided, the value of the field is shown).',
   });
+  argparser.add_argument('--extra', {
+    action: 'store_true',
+    help: 'The field is in the extra field instead of the zotero official fields.',
+  });
   argparser.add_argument('--version', {
     nargs: 1,
     help: 'You have to supply the version of the item via the --version argument or else the latest version will be used.',

--- a/src/zotero-interface.ts
+++ b/src/zotero-interface.ts
@@ -173,6 +173,7 @@ namespace ZoteroTypes {
   export interface fieldArgs extends ZoteroTypes.ItemArgs {
     field: string;
     value?: string;
+    extra?: boolean;
   }
 
   export interface update_urlArgs extends ZoteroTypes.update_itemArgs {


### PR DESCRIPTION
## Add extra field manipulation read field and write field

### examples used

-  View current `gsrank` extra field

```bash
npm run dev -- field --extra  --key zotero://select/groups/5478983/items/9DIDHVUE --field gsrank  
```

- Modify `gsrank extra field

```bash
npm run dev -- field --extra  --key zotero://select/groups/5478983/items/9DIDHVUE --field gsrank --value 999 
```

- Add new field to extra field

```bash
npm run dev -- field --extra  --key zotero://select/groups/5478983/items/9DIDHVUE --field test_api --value 'can add'
```

- Test that the code didn't broke for other than extra field

```bash
npm run dev -- field  --key zotero://select/groups/5478983/items/9DIDHVUE --field date --value 9999
```

